### PR TITLE
Don't hardcode python path

### DIFF
--- a/freck
+++ b/freck
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
 import base64


### PR DESCRIPTION
For various reasons the script might be run by a different Python interpreter
than `/usr/bin/python`, which is made easier by this commit.
